### PR TITLE
Fix typo in rescue handler

### DIFF
--- a/app/controllers/admin/forest_controller.rb
+++ b/app/controllers/admin/forest_controller.rb
@@ -12,7 +12,7 @@ class Admin::ForestController < ApplicationController
 
   after_action :verify_authorized, unless: :devise_controller?
 
-  rescue_from ActiveRecord::InvalidForeignKey, with: :foreign_key_contraint
+  rescue_from ActiveRecord::InvalidForeignKey, with: :foreign_key_constraint
   rescue_from ActiveRecord::RecordNotUnique, with: :record_not_unique
 
   # rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
@@ -78,7 +78,7 @@ class Admin::ForestController < ApplicationController
     instance_variable_get("@#{controller_name.singularize}")
   end
 
-  def foreign_key_contraint(exception)
+  def foreign_key_constraint(exception)
     if record
       statusable_message = record.try(:statusable?) ? ' Alternatively, you may want to set this record\'s status to hidden instead.' : ''
       error_messages = ["This record can't be deleted because another record depends on it. First remove the association to the other record before deleting this one.#{statusable_message}", "<code>#{exception.message}</code>"]


### PR DESCRIPTION
## Summary
- fix a spelling mistake in `Admin::ForestController`

## Testing
- `bundle exec rake test` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e94451883238f851afa34ada6d3